### PR TITLE
Print API set namespace sealed status

### DIFF
--- a/APISetMap/APISetMap.cpp
+++ b/APISetMap/APISetMap.cpp
@@ -5,7 +5,7 @@
 
 void PrintHeader() {
 	printf("ApiSetMap - list API Set mappings - version 1.0\n");
-	printf("(C)2017 Alex Ionescu and Pavel Yosifovich\n");
+	printf("(c) Alex Ionescu, Pavel Yosifovich, and Contributors\n");
 	printf("http://www.alex-ionescu.com\n\n");
 }
 
@@ -22,13 +22,15 @@ int main() {
 	UNICODE_STRING nameString, valueString;
 
 	for (ULONG i = 0; i < apiSetMap->Count; i++) {
+		auto isSealed = nsEntry->Flags & API_SET_SCHEMA_ENTRY_FLAGS_SEALED != 0;
+
 		//
 		// Build a UNICODE_STRING for this contract
 		//
 		nameString.MaximumLength = static_cast<USHORT>(nsEntry->NameLength);
 		nameString.Length = static_cast<USHORT>(nsEntry->NameLength);
 		nameString.Buffer = reinterpret_cast<PWCHAR>(apiSetMapAsNumber + nsEntry->NameOffset);
-		printf("%56wZ.dll -> {", &nameString);
+		printf("%56wZ.dll -> %s{", &nameString, (isSealed ? "s" : "" ));
 
 		//
 		// Iterate the values (i.e.: the hosts for this set)

--- a/APISetMap/ApiSet.h
+++ b/APISetMap/ApiSet.h
@@ -1,11 +1,6 @@
 #pragma once
 
-LONG
-RtlCompareUnicodeString(
-	_In_ PUNICODE_STRING Src1,
-	_In_ PUNICODE_STRING Src2,
-	_In_ BOOLEAN CaseInSensitive
-);
+#define API_SET_SCHEMA_ENTRY_FLAGS_SEALED 1
 
 typedef struct _API_SET_NAMESPACE {
 	ULONG Version;


### PR DESCRIPTION
Shows a small `s` next to each set of api set hosts to denote whether or not the api set namespace is sealed (i.e. if additional hosts can be added).

Example output:
```
     ext-ms-win-ntos-kcminitcfg-l1-1-0.dll -> s{cmimcext.sys}
                        ext-ms-win-ntos-ksecurity-l1-1-1.dll -> s{}
                   ext-ms-win-ntos-ksigningpolicy-l1-1-0.dll -> s{}
                              ext-ms-win-ntos-ksr-l1-1-2.dll -> {}
                  ext-ms-win-ntos-stateseparation-l1-1-0.dll -> s{}
                               ext-ms-win-ntos-tm-l1-1-0.dll -> s{tm.sys}
                            ext-ms-win-ntos-trace-l1-1-0.dll -> {}
                            ext-ms-win-ntos-ucode-l1-1-0.dll -> s{ntosext.sys}
                            ext-ms-win-ntos-vmsvc-l1-1-0.dll -> {}
```