### PR TITLE
Support Win10 - modify _PF_MEMORY_RANGE_INFO

### DIFF
--- a/MemInfo/MemInfo.cpp
+++ b/MemInfo/MemInfo.cpp
@@ -60,9 +60,10 @@ NTSTATUS PfiQueryMemoryRanges() {
 	ULONG ResultLength = 0;
 
 	//
-	// Memory Ranges API was added in RTM, this is Version 1
+	// Memory Ranges API was added in RTM, this is Version 1. Since Windows 10 it is Version 2.
 	//
-	MemoryRangeInfo.Version = 1;
+	MemoryRangeInfo.Version = 2;
+	MemoryRangeInfo.flags = 0;
 
 	//
 	// Build the Superfetch Information Buffer
@@ -84,7 +85,8 @@ NTSTATUS PfiQueryMemoryRanges() {
 		// Reallocate memory
 		//
 		MemoryRanges = static_cast<PPF_MEMORY_RANGE_INFO>(::HeapAlloc(GetProcessHeap(), 0, ResultLength));
-		MemoryRanges->Version = 1;
+		MemoryRanges->Version = 2;
+		MemoryRanges->flags = 0;
 
 		//
 		// Rebuild the buffer

--- a/MemInfo/MemInfo.h
+++ b/MemInfo/MemInfo.h
@@ -139,11 +139,21 @@ typedef struct _PF_PHYSICAL_MEMORY_RANGE {
 	ULONG_PTR PageCount;
 } PF_PHYSICAL_MEMORY_RANGE, *PPF_PHYSICAL_MEMORY_RANGE;
 
+/*
 typedef struct _PF_MEMORY_RANGE_INFO {
 	ULONG Version;
 	ULONG RangeCount;
 	PF_PHYSICAL_MEMORY_RANGE Ranges[ANYSIZE_ARRAY];
 } PF_MEMORY_RANGE_INFO, *PPF_MEMORY_RANGE_INFO;
+*/
+//Information from https://blog.midi12.re/systemsuperfetchinformation/
+typedef struct _PF_MEMORY_RANGE_INFO {
+	ULONG Version;
+	ULONG flags; // added between 10_1709_16299_248 and 10_1803_17134_81
+	ULONG RangeCount;
+	PF_PHYSICAL_MEMORY_RANGE Ranges[ANYSIZE_ARRAY];
+} PF_MEMORY_RANGE_INFO, * PPF_MEMORY_RANGE_INFO;
+
 
 //
 // Sub-Information Types for PFN Identity


### PR DESCRIPTION
Support Win10 - modify _PF_MEMORY_RANGE_INFO structure, set version to 2 and flags to 0.

Found information on https://blog.midi12.re/systemsuperfetchinformation/ from @midi12.

We should add a function for "Windows version test", but I don't know what is the best strategy for this and wanted a light PR.

Tested on Microsoft Windows [Version 10.0.19045.4291] and Microsoft Windows [Version 10.0.19045.4170]